### PR TITLE
Upgraded libsla usage, improved build steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,11 @@ This fuzzer uses Address Sanitizer (ASAN) which requires Rust nightly compiler.
 # One time setup to initialize the corpus directory
 ./build-corpus.rs
 
-# Build with ASAN to ensure ASAN libraries are linked
-cargo +nightly rustc -- -Z sanitizer=address
-
 # Create input directory
 mkdir input
 
-# Run the fuzzer
-./target/debug/sla-fuzz input corpus
+# Build with ASAN and run fuzzer
+RUSTFLAGS="-Zsanitizer=address" cargo +nightly run --target x86_64-unknown-linux-gnu --release -- input corpus
 ```
 
 ## Expected output

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(not(test), no_main)]
 
 use libfuzzer_sys::fuzz_target;
-use libsla::{GhidraSleigh, SlaDecoder};
+use libsla::{GhidraSleigh, SlaDataEncoding};
 
 fuzz_target!(|data: &[u8]| {
     let _ = GhidraSleigh::builder()
         .processor_spec("<processor_spec></processor_spec>")
         .expect("processor spec should be valid")
-        .sla_decoder(SlaDecoder::Raw)
+        .sla_encoding(SlaDataEncoding::Raw)
         .build(data);
 });


### PR DESCRIPTION
Fixed usage of preliminary `libsla` types and updated README.md to use `cargo run` for running the fuzzer instead of splitting the steps into a separate `rustc` invocation. The key here to making the direct `cargo` commands work was discovering that the `--target` triple was required. Source: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#build-scripts-and-procedural-macros